### PR TITLE
dont generate pointer type for enum

### DIFF
--- a/generator/output/echo.go
+++ b/generator/output/echo.go
@@ -25,20 +25,6 @@ var (
 	rgxSyntaxError = regexp.MustCompile(`(\d+):\d+: `)
 )
 
-func toGoType(dataType string, label string) string {
-	// if not primary type return data type and ignore the . in the data type
-	if _, ok := wrapperTypes[dataType]; !ok {
-		dataType = "*" + dataType
-	}
-
-	// check if the field is repeated
-	if label == data.FieldRepeatedLabel {
-		dataType = "[]" + dataType
-	}
-
-	return dataType
-}
-
 type echoGen struct {
 	ApplicationName string
 	PackageName     string
@@ -96,10 +82,10 @@ func (g *echoGen) getStructFilename(packageName string, msg *data.MessageData) s
 	return packageName + "/" + msg.Name + ".go"
 }
 
-func (g *echoGen) genStruct(msg *data.MessageData) string {
+func (g *echoGen) genStruct(msg *data.MessageData, enums []*data.EnumData) string {
 	buf := bytes.NewBufferString("")
 
-	obj := newEchoStruct(msg, g.PackageName)
+	obj := newEchoStruct(msg, g.PackageName, enums)
 	err := g.structTpl.Execute(buf, obj)
 	if err != nil {
 		util.Die(err)
@@ -184,7 +170,7 @@ func (g *echoGen) Gen(applicationName string, packageName string, service *data.
 
 	for _, msg := range messages {
 		filename := g.getStructFilename(g.PackageName, msg)
-		content := g.genStruct(msg)
+		content := g.genStruct(msg, enums)
 
 		result[filename] = content
 	}

--- a/test/expected/go/apisvr/Error.go
+++ b/test/expected/go/apisvr/Error.go
@@ -4,13 +4,13 @@ package apisvr
 
 // Error
 type Error struct {
-	Code    *ErrorCode `json:"code"`
-	Message string     `json:"message"`
+	Code    ErrorCode `json:"code"`
+	Message string    `json:"message"`
 }
 
-func (r *Error) GetCode() *ErrorCode {
+func (r *Error) GetCode() ErrorCode {
 	if r == nil {
-		var zeroVal *ErrorCode
+		var zeroVal ErrorCode
 		return zeroVal
 	}
 	return r.Code

--- a/test/expected/go/apisvr/FieldError.go
+++ b/test/expected/go/apisvr/FieldError.go
@@ -4,8 +4,8 @@ package apisvr
 
 // FieldError
 type FieldError struct {
-	FieldName string             `json:"fieldName"`
-	ErrorType *ValidateErrorType `json:"errorType"`
+	FieldName string            `json:"fieldName"`
+	ErrorType ValidateErrorType `json:"errorType"`
 }
 
 func (r *FieldError) GetFieldName() string {
@@ -16,9 +16,9 @@ func (r *FieldError) GetFieldName() string {
 	return r.FieldName
 }
 
-func (r *FieldError) GetErrorType() *ValidateErrorType {
+func (r *FieldError) GetErrorType() ValidateErrorType {
 	if r == nil {
-		var zeroVal *ValidateErrorType
+		var zeroVal ValidateErrorType
 		return zeroVal
 	}
 	return r.ErrorType

--- a/test/expected/go/calcsvr/FieldError.go
+++ b/test/expected/go/calcsvr/FieldError.go
@@ -4,8 +4,8 @@ package calcsvr
 
 // FieldError
 type FieldError struct {
-	FieldName string             `json:"fieldName"`
-	ErrorType *ValidateErrorType `json:"errorType"`
+	FieldName string            `json:"fieldName"`
+	ErrorType ValidateErrorType `json:"errorType"`
 }
 
 func (r *FieldError) GetFieldName() string {
@@ -16,9 +16,9 @@ func (r *FieldError) GetFieldName() string {
 	return r.FieldName
 }
 
-func (r *FieldError) GetErrorType() *ValidateErrorType {
+func (r *FieldError) GetErrorType() ValidateErrorType {
 	if r == nil {
-		var zeroVal *ValidateErrorType
+		var zeroVal ValidateErrorType
 		return zeroVal
 	}
 	return r.ErrorType

--- a/test/expected/go/todolistsvr/FieldError.go
+++ b/test/expected/go/todolistsvr/FieldError.go
@@ -4,8 +4,8 @@ package todolistsvr
 
 // FieldError
 type FieldError struct {
-	FieldName string             `json:"fieldName"`
-	ErrorType *ValidateErrorType `json:"errorType"`
+	FieldName string            `json:"fieldName"`
+	ErrorType ValidateErrorType `json:"errorType"`
 }
 
 func (r *FieldError) GetFieldName() string {
@@ -16,9 +16,9 @@ func (r *FieldError) GetFieldName() string {
 	return r.FieldName
 }
 
-func (r *FieldError) GetErrorType() *ValidateErrorType {
+func (r *FieldError) GetErrorType() ValidateErrorType {
 	if r == nil {
-		var zeroVal *ValidateErrorType
+		var zeroVal ValidateErrorType
 		return zeroVal
 	}
 	return r.ErrorType

--- a/util/protoapi_include.go
+++ b/util/protoapi_include.go
@@ -212,16 +212,16 @@ var _escData = map[string]*_escFile{
 	"/proto/protoapi_common.proto": {
 		name:    "protoapi_common.proto",
 		local:   "proto/protoapi_common.proto",
-		size:    795,
+		size:    869,
 		modtime: 0,
 		compressed: `
-H4sIAAAAAAAC/4SSz27yMBDE73mKFQ/Af77vgHKgJVSRgKqo5RoZsgRLsZ2uHQRCvHtlm0CiUnGzfzvM
-DOvokzTsCCG0ClJGDVrjIOCiUGSglSmV5dhxg02566Sot8QLo6jtmNXi0aBMwUvblbS9QLNX6XthuJIa
-zgGANsRlBhrpwLeYCCeAEEa9bvff+C5AIkVX/n8cXP6MmHHMHyUcWJ7sFAlmri59675RKncjwu+SE1bR
-Azvk0gz6ILi8wmENuuVYOHJlBGrNMoRXJYSSkStrw99QIvGtB1n9EkLP2k1Ks/eA3U4huG5rlvOUGfTw
-0LiF4Bq+cJl6sLmdQhg2KjUqnKt1VFNbA2rqe5+n0nv4U2nzr5yBsEBmMAX3Wp66F9a/flpT1F5zZ+mS
-Caz22Ej4PBXo/dzJ7dN+MbIUD4TWNl6uJ/N4mkSLSTyHELrWcxZH82myij6+4lU09UmX4CcAAP//DDA1
-xBsDAAA=
+H4sIAAAAAAAC/4SSzW7qMBCF93mKEQ/AP/deCXnBLaGKBFSlLdvIJEOwFNup7SAQ4t0r2wQSlZadfebk
+zOeZ6KMw9AAEWoWSRg5a4yBgvJDKQCuTMsux4wqbcttJUSeKFUaqttOsFw8GRQre2q6s7QWanUxfCsOk
+0HAKALRRTGSgUe1ZgjF3BiAw6nW7f8Y3Ayol1UX/Ow7OP7Z480l3eiSScynietK/35JmDPN7rHuax1up
+ODWXlL7l3EiZu5LCz5IprB4xsEUmzKAPnImLOKyJbsxWHDkYjlrTDOHJ0YYO1jZ/RoGKJV7I6hcCPRs3
+Kc3OC/R6IuDY1jRnKTXoxX3jRsAR/mci9cLmeiIwbCA1EE7VOKqqxYCa+8bz0Hpr/tDafMoJFBZIDabg
+tuVVt2H97dOao7bNrVWXlGM1x0aH92OBPs+d3DztHyNKfsdoY6PlejKPpnG4mERzINC1mbMonE/jVfj6
+Ea3Cqe90Dr4CAAD//wzqA9RlAwAA
 `,
 	},
 


### PR DESCRIPTION
this change is to generate structure field which is enum type as concrete instead of pointer. This is the same for protobuf generated go code for proto3. 